### PR TITLE
Fixed kdcHost set to None

### DIFF
--- a/getnthash.py
+++ b/getnthash.py
@@ -51,7 +51,7 @@ from impacket.krb5.types import Principal, KerberosTime, Ticket
 from impacket.winregistry import hexdump
 
 
-class GETPAC:
+class GETPAC(object):
 
     def printPac(self, data, key=None):
         encTicketPart = decoder.decode(data, asn1Spec=EncTicketPart())[0]
@@ -208,7 +208,7 @@ class GETPAC:
         message = encoder.encode(tgsReq)
         logging.info('Requesting ticket to self with PAC')
 
-        r = sendReceive(message, self.__domain, None)
+        r = sendReceive(message, self.__domain, self.__kdcHost)
 
         tgs = decoder.decode(r, asn1Spec = TGS_REP())[0]
 


### PR DESCRIPTION
When requesting for the ticket, the `sendReceive()` function was called with the `kdcHost` argument set to None, preventing the script to work when not having DNS resolution set properly on the host.

```sh
python3 getnthash.py -key "2ddb [...] 9969" -dc-ip "192.168.56.101" "domain.local/user2"
Impacket v0.9.24.dev1+20210706.140217.6da655ca - Copyright 2021 SecureAuth Corporation

[*] Using TGT from cache
[*] Requesting ticket to self with PAC
[-] [Errno Connection error (DOMAIN.LOCAL:88)] [Errno -2] Name or service not known
```